### PR TITLE
Add Jest tests for formatSeconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@
  * @LastEditTime: 2022-07-04 11:24:06
 -->
 #vue3+TS版本的成德南相关代码# fireweb
+
+## Running tests
+
+Use `npm test` to run the unit test suite.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build:dev": "webpack  --config ./webpack.dev.js",
     "build": "webpack  --config ./webpack.pro.js",
     "dev": "webpack serve --config ./webpack.dev.js",
-    "pro": "webpack serve --config ./webpack.pro.js"
+    "pro": "webpack serve --config ./webpack.pro.js",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -99,6 +100,9 @@
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.3",
-    "webpack-merge": "^5.8.0"
+    "webpack-merge": "^5.8.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }

--- a/tests/unit/tool.test.ts
+++ b/tests/unit/tool.test.ts
@@ -1,0 +1,19 @@
+import { formatSeconds } from '../../src/utils/tool'
+
+describe('formatSeconds', () => {
+  it('handles seconds less than 60', () => {
+    expect(formatSeconds(45 * 1000)).toBe('45秒')
+  })
+
+  it('handles minutes', () => {
+    expect(formatSeconds(90 * 1000)).toBe('1分30秒')
+  })
+
+  it('handles hours', () => {
+    expect(formatSeconds(3661 * 1000)).toBe('1小时1分1秒')
+  })
+
+  it('handles days', () => {
+    expect(formatSeconds(2 * 24 * 60 * 60 * 1000)).toBe('2天')
+  })
+})


### PR DESCRIPTION
## Summary
- add Jest with ts-jest support
- create unit tests for `formatSeconds`
- document how to run tests in README

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855198605988322906f25f1ca0039a5