### PR TITLE
Fix comparison in upgrade status

### DIFF
--- a/src/utils/tool.ts
+++ b/src/utils/tool.ts
@@ -235,9 +235,9 @@ export const myupgrade = function (status: number, result: number) {
   if (status == 1) {
     return name
   } else {
-    if ((result = 0)) {
+    if (result === 0) {
       return label
-    } else if ((result = 1)) {
+    } else if (result === 1) {
       return labeltwo
     } else {
       return labelthree


### PR DESCRIPTION
## Summary
- fix boolean comparisons in `myupgrade`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68551984474c832297b5a4c624710625